### PR TITLE
Update to Trino 468, Phileas 2.10.0, JDK 23

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2024-2025 Philterd, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ select phileas_redact('my email is rik@resurfacd.io')
 ```
 
 ---
-Copyright 2024 Philterd, LLC @ https://www.philterd.ai
+Copyright 2024-2025 Philterd, LLC @ https://www.philterd.ai

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Phileas functions for Trino
 This [Trino](https://trino.io) connector uses [Phileas](https://github.com/philterd/phileas) to detect and redact PII tokens.
 Simple scalar functions are provided to redact `varchar` data provided by any other Trino data source.
 
-[![CodeFactor](https://www.codefactor.io/repository/github/resurfaceio/phileas-connector/badge)](https://www.codefactor.io/repository/github/resurfaceio/phileas-connector)
+[![CodeFactor](https://www.codefactor.io/repository/github/philterd/phileas-connector/badge)](https://www.codefactor.io/repository/github/philterd/phileas-connector)
 
 ## Dependencies
 
-* Java 22
+* Java 23
 * Maven 3.9.x
 * [philterd/phileas](https://github.com/philterd/phileas) 
-* Trino 452 or higher
+* Trino 468
 
 ## Configuring Trino
 
@@ -23,10 +23,10 @@ export TRINO_HOME=$HOME/...
 
 2. Create $TRINO_HOME/etc/catalog/phileas.properties:
 connector.name=phileas
-connector.policy.file=/Users/me/policy.txt
+phileas.policy.file=/Users/me/policy.txt
 
 3. Build the connector and redeploy
-mvn clean package && rm -rf $TRINO_HOME/plugin/phileas && cp -r ./target/phileas-connector-0.0.1 $TRINO_HOME/plugin/phileas
+mvn clean package && rm -rf $TRINO_HOME/plugin/phileas && cp -r ./target/phileas-connector-468 $TRINO_HOME/plugin/phileas
 
 4. Start Trino
 cd $TRINO_HOME

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.philterd</groupId>
     <artifactId>phileas-connector</artifactId>
-    <version>0.0.1</version>
+    <version>468</version>
     <name>phileas-connector</name>
     <description>Phileas connector for Trino</description>
     <url>https://github.com/resurfaceio/phileas-connector</url>
@@ -62,22 +62,22 @@
         <dependency>
             <groupId>ai.philterd</groupId>
             <artifactId>phileas-core</artifactId>
-            <version>2.7.0-SNAPSHOT</version>
+            <version>2.10.0</version>
         </dependency>
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>bootstrap</artifactId>
-            <version>250</version>
+            <version>294</version>
         </dependency>
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>configuration</artifactId>
-            <version>250</version>
+            <version>294</version>
         </dependency>
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>json</artifactId>
-            <version>250</version>
+            <version>294</version>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>
@@ -94,31 +94,31 @@
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-spi</artifactId>
-            <version>452</version>
+            <version>468</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
-            <version>2.2</version>
+            <version>2.3</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.17.2</version>
+            <version>2.18.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
-            <version>1.39.0</version>
+            <version>1.45.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-context</artifactId>
-            <version>1.39.0</version>
+            <version>1.45.0</version>
             <scope>provided</scope>
         </dependency>
 
@@ -126,13 +126,13 @@
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-main</artifactId>
-            <version>452</version>
+            <version>468</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-testing</artifactId>
-            <version>452</version>
+            <version>468</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -163,8 +163,8 @@
 
     <properties>
         <air.main.basedir>${project.basedir}</air.main.basedir>
-        <maven.compiler.source>22</maven.compiler.source>
-        <maven.compiler.target>22</maven.compiler.target>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/main/java/ai/philterd/phileas/trino/connector/PhileasConfig.java
+++ b/src/main/java/ai/philterd/phileas/trino/connector/PhileasConfig.java
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2024 Philterd, LLC @ https://www.philterd.ai
+ *     Copyright 2024-2025 Philterd, LLC @ https://www.philterd.ai
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ai/philterd/phileas/trino/connector/PhileasConnector.java
+++ b/src/main/java/ai/philterd/phileas/trino/connector/PhileasConnector.java
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2024 Philterd, LLC @ https://www.philterd.ai
+ *     Copyright 2024-2025 Philterd, LLC @ https://www.philterd.ai
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ai/philterd/phileas/trino/connector/PhileasConnectorFactory.java
+++ b/src/main/java/ai/philterd/phileas/trino/connector/PhileasConnectorFactory.java
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2024 Philterd, LLC @ https://www.philterd.ai
+ *     Copyright 2024-2025 Philterd, LLC @ https://www.philterd.ai
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ai/philterd/phileas/trino/connector/PhileasFunctions.java
+++ b/src/main/java/ai/philterd/phileas/trino/connector/PhileasFunctions.java
@@ -45,7 +45,7 @@ public final class PhileasFunctions {
     @SqlType("varchar")
     public static Slice redact(@SqlType("varchar") Slice s) {
         try {
-            return s == null ? null : slice(filterService.filter(policy, "<cxt>", "<doc>", s.toStringUtf8(), MimeType.TEXT_PLAIN).filteredText());
+            return s == null ? null : slice(filterService.filter(policy, "<cxt>", "<doc>", s.toStringUtf8(), MimeType.TEXT_PLAIN).getFilteredText());
         } catch (Exception e) {
             log.error(e);
             return null;

--- a/src/main/java/ai/philterd/phileas/trino/connector/PhileasFunctions.java
+++ b/src/main/java/ai/philterd/phileas/trino/connector/PhileasFunctions.java
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2024 Philterd, LLC @ https://www.philterd.ai
+ *     Copyright 2024-2025 Philterd, LLC @ https://www.philterd.ai
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ai/philterd/phileas/trino/connector/PhileasModule.java
+++ b/src/main/java/ai/philterd/phileas/trino/connector/PhileasModule.java
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2024 Philterd, LLC @ https://www.philterd.ai
+ *     Copyright 2024-2025 Philterd, LLC @ https://www.philterd.ai
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ai/philterd/phileas/trino/connector/PhileasPlugin.java
+++ b/src/main/java/ai/philterd/phileas/trino/connector/PhileasPlugin.java
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2024 Philterd, LLC @ https://www.philterd.ai
+ *     Copyright 2024-2025 Philterd, LLC @ https://www.philterd.ai
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ai/philterd/phileas/trino/connector/TestPhileasConfig.java
+++ b/src/test/java/ai/philterd/phileas/trino/connector/TestPhileasConfig.java
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2024 Philterd, LLC @ https://www.philterd.ai
+ *     Copyright 2024-2025 Philterd, LLC @ https://www.philterd.ai
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ai/philterd/phileas/trino/connector/TestPhileasFunctions.java
+++ b/src/test/java/ai/philterd/phileas/trino/connector/TestPhileasFunctions.java
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2024 Philterd, LLC @ https://www.philterd.ai
+ *     Copyright 2024-2025 Philterd, LLC @ https://www.philterd.ai
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description
Brings connector up to latest versions of major dependencies

### Issues Resolved
No changes in behavior, size of connector reduced from 166 MB to 44 MB 🤩

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
